### PR TITLE
Remove the Automatic Download Parameter from Dataset Classes

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -7,7 +7,7 @@ The `imds` package provides PyTorch-compatible dataset classes for common image 
 ## Installation
 
 ```bash
-pip install git+https://github.com/cainspencerm/image-manipulation-datasets.git@0.6
+pip install image-manipulation-datasets
 ```
 
 ## Core Components

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -21,7 +21,6 @@ All dataset classes share these common initialization parameters:
 - **`crop_size`** (Tuple[int, int], optional): Size of crops to apply to images and masks. If `None`, uses original image size. Default: `None`
 - **`pixel_range`** (Tuple[float, float], optional): Target pixel value range for normalization. Default: `(0.0, 1.0)`
 - **`shuffle`** (bool, optional): Whether to shuffle the dataset before splitting into train/valid/test. This is different from DataLoader shuffling - this parameter controls the initial randomization of the entire dataset before creating splits, while DataLoader shuffling randomizes batch order during training. Default: `True`
-- **`download`** (bool, optional): Whether to download the dataset (not implemented). Default: `False`
 
 #### Common Methods
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Python package provides PyTorch-compatible dataset classes for common image
 ## Installation
 
 ```bash
-pip install git+https://github.com/cainspencerm/image-manipulation-datasets.git@0.6
+pip install image-manipulation-datasets
 ```
 
 ## Quick Start

--- a/src/imds/casia/casia2.py
+++ b/src/imds/casia/casia2.py
@@ -38,7 +38,6 @@ class CASIA2(_BaseDataset):
         pixel_range (tuple): The range of the pixel values of the input images.
             Ex. (0, 1) scales the pixels from [0, 255] to [0, 1].
         shuffle (bool): Whether to shuffle the dataset before splitting.
-        download (bool): Whether to download the dataset.
     """
 
     def __init__(
@@ -48,16 +47,8 @@ class CASIA2(_BaseDataset):
         crop_size: Tuple[int, int] = None,
         pixel_range: Tuple[float, float] = (0.0, 1.0),
         shuffle: bool = True,
-        download: bool = False,
     ) -> None:
         super().__init__(crop_size, pixel_range)
-
-        if download:
-            raise NotImplementedError(
-                "Downloading is not implemented yet due to the requirement of a "
-                "browser to obtain the dataset. Please refer to the following link "
-                "for more information: https://github.com/namtpham/casia2groundtruth."
-            )
 
         # Fetch the image filenames.
         authentic_dir = os.path.join(data_dir, "Au")

--- a/src/imds/coverage/coverage.py
+++ b/src/imds/coverage/coverage.py
@@ -49,7 +49,6 @@ class Coverage(_BaseDataset):
         pixel_range (tuple): The range of the pixel values of the input images.
             Ex. (0, 1) scales the pixels from [0, 255] to [0, 1].
         shuffle (bool): Whether to shuffle the dataset before splitting.
-        download (bool): Whether to download the dataset.
     """
 
     def __init__(
@@ -59,18 +58,10 @@ class Coverage(_BaseDataset):
         crop_size: Tuple[int, int] = None,
         pixel_range: Tuple[float, float] = (0.0, 1.0),
         shuffle: bool = True,
-        download: bool = False,
     ) -> None:
         super().__init__(crop_size, pixel_range)
 
         assert mask_type in ["forged", "copy", "paste"]
-
-        if download:
-            raise NotImplementedError(
-                "Downloading is not implemented yet due to the requirement of a "
-                "browser to obtain the dataset. Please refer to the following link "
-                "for more information: https://github.com/wenbihan/coverage."
-            )
 
         # Fetch the image filenames.
         image_dir = os.path.join(data_dir, "image")

--- a/src/imds/defacto/copymove.py
+++ b/src/imds/defacto/copymove.py
@@ -67,7 +67,6 @@ class CopyMove(_BaseDataset):
         pixel_range (tuple): The range of the pixel values of the input images.
             Ex. (0, 1) scales the pixels from [0, 255] to [0, 1].
         shuffle (bool): Whether to shuffle the dataset before splitting.
-        download (bool): Whether to download the dataset.
     """
 
     def __init__(
@@ -77,16 +76,8 @@ class CopyMove(_BaseDataset):
         crop_size: Tuple[int, int] = None,
         pixel_range: Tuple[float, float] = (0.0, 1.0),
         shuffle: bool = True,
-        download: bool = False,
     ) -> None:
         super().__init__(crop_size, pixel_range)
-
-        if download:
-            raise NotImplementedError(
-                "Downloading is not implemented yet due to the requirement of a "
-                "browser to obtain the dataset. Please refer to the following link "
-                "for more information: https://defactodataset.github.io."
-            )
 
         # Fetch the image filenames.
         image_dir = os.path.join(data_dir, "copymove_img", "img")

--- a/src/imds/defacto/inpainting.py
+++ b/src/imds/defacto/inpainting.py
@@ -67,7 +67,6 @@ class Inpainting(_BaseDataset):
         pixel_range (tuple): The range of the pixel values of the input images.
             Ex. (0, 1) scales the pixels from [0, 255] to [0, 1].
         shuffle (bool): Whether to shuffle the dataset before splitting.
-        download (bool): Whether to download the dataset.
     """
 
     def __init__(
@@ -77,16 +76,8 @@ class Inpainting(_BaseDataset):
         crop_size: Tuple[int, int] = None,
         pixel_range: Tuple[float, float] = (0.0, 1.0),
         shuffle: bool = True,
-        download: bool = False,
     ) -> None:
         super().__init__(crop_size, pixel_range)
-
-        if download:
-            raise NotImplementedError(
-                "Downloading is not implemented yet due to the requirement of a "
-                "browser to obtain the dataset. Please refer to the following link "
-                "for more information: https://defactodataset.github.io."
-            )
 
         # Fetch the image filenames.
         image_dir = os.path.join(data_dir, "inpainting_img", "img")

--- a/src/imds/defacto/splicing.py
+++ b/src/imds/defacto/splicing.py
@@ -91,7 +91,6 @@ class Splicing(_BaseDataset):
         pixel_range (tuple): The range of the pixel values of the input images.
             Ex. (0, 1) scales the pixels from [0, 255] to [0, 1].
         shuffle (bool): Whether to shuffle the dataset before splitting.
-        download (bool): Whether to download the dataset.
     """
 
     def __init__(
@@ -101,16 +100,8 @@ class Splicing(_BaseDataset):
         crop_size: Tuple[int, int] = (256, 256),
         pixel_range: Tuple[float, float] = (0.0, 1.0),
         shuffle: bool = True,
-        download: bool = False,
     ) -> None:
         super().__init__(crop_size, pixel_range)
-
-        if download:
-            raise NotImplementedError(
-                "Downloading is not implemented yet due to the requirement of a "
-                "browser to obtain the dataset. Please refer to the following link "
-                "for more information: https://defactodataset.github.io."
-            )
 
         # Fetch the image filenames.
         image_dirs = [

--- a/src/imds/imd/imd2020.py
+++ b/src/imds/imd/imd2020.py
@@ -40,7 +40,6 @@ class IMD2020(_BaseDataset):
         pixel_range (tuple): The range of the pixel values of the input images.
             Ex. (0, 1) scales the pixels from [0, 255] to [0, 1].
         shuffle (bool): Whether to shuffle the dataset before splitting.
-        download (bool): Whether to download the dataset.
     """
 
     def __init__(
@@ -50,16 +49,8 @@ class IMD2020(_BaseDataset):
         crop_size: Tuple[int, int] = None,
         pixel_range: Tuple[float, float] = (0.0, 1.0),
         shuffle: bool = True,
-        download: bool = False,
     ) -> None:
         super().__init__(crop_size, pixel_range)
-
-        if download:
-            raise NotImplementedError(
-                "Downloading is not implemented yet due to the requirement of a "
-                "browser to obtain the dataset. Please refer to the following link "
-                "for more information: http://staff.utia.cas.cz/novozada/db/."
-            )
 
         subdirs = [
             os.path.join(data_dir, subdir)


### PR DESCRIPTION
For the foreseeable future, legal data hosting options will not be pursued to enable this functionality. Currently, it raises errors on usage. This PR removes the functionality entirely.